### PR TITLE
Fix path to generated files

### DIFF
--- a/gqlgen/def.bzl
+++ b/gqlgen/def.bzl
@@ -143,8 +143,8 @@ def _gqlgen_impl(ctx):
         command = "cp %s %s" % (ctx.file.gosum.path, gosum_file.path),
     )
 
-    out_generated_file = ctx.actions.declare_file("graph/generated/generated.go")
-    out_models_file = ctx.actions.declare_file("graph/model/models_gen.go")
+    out_generated_file = ctx.actions.declare_file("generated/generated.go")
+    out_models_file = ctx.actions.declare_file("model/models_gen.go")
 
     ctx.actions.run(
         inputs = ctx.files.schemas + [


### PR DESCRIPTION
Remove the `graph/` prefix, which is a vestige of how this used to be generated. Now, `base_importpath` can be wherever, no `graph` needed.
