### PR TITLE
Update example BUILD.bazel to include go.{mod,sum}

### DIFF
--- a/example/BUILD.bazel
+++ b/example/BUILD.bazel
@@ -6,6 +6,8 @@ gqlgen(
     base_importpath = "github.com/Silicon-Ally/rules_gqlgen/example",
     schemas = [":schema.graphqls"],
     visibility = ["//visibility:public"],
+    gomod = "//:go.mod",
+    gosum = "//:go.sum",
 )
 
 go_library(


### PR DESCRIPTION
This will be required by others using this package, but isn't required for `//example` because it lives in the same namespace as rules_gqlgen.
