### PR TITLE
Add macos platform to gh actions build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,10 @@ on: push
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
I'm investigating why the rule is breaking the example on MacOS. Thought I'd share the "broken test" with you in case you are interested.