### PR TITLE
Fix macos build failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: push
+on: pull_request
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,10 @@ on: push
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,9 @@
 name: Build
-
-on: pull_request
-
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 jobs:
   build:
     strategy:

--- a/gqlgen/generate.sh
+++ b/gqlgen/generate.sh
@@ -1,18 +1,23 @@
 #!/bin/bash
 set -euo pipefail
 
+# This does not handle the case where $1 is a symlink itself.
+unroll_path() {
+  echo "$( cd -- "$(dirname -- "$1")" ; pwd -P )/$( basename -- "$1")"
+}
+
 # Give our input arguments more semantic names, see def.bzl for more info.
 CONFIG="$1"
-OUT_GEN_FILE="$(realpath "$2")"
-OUT_MODELS_FILE="$(realpath "$3")"
-GQL_ZIP="$(realpath "$4")"
+OUT_GEN_FILE="$(unroll_path "$2")"
+OUT_MODELS_FILE="$(unroll_path "$3")"
+GQL_ZIP="$(unroll_path "$4")"
 CONFIG_DIR="$5"
 GO_MOD="$6"
 GO_SUM="$7"
 MODCACHER_PATH="$8"
 
 TMP_ROOT="$(mktemp -d)"
-export GOROOT="$(realpath "$GOROOT")"
+export GOROOT="$(unroll_path "$GOROOT")"
 export GOPATH="$TMP_ROOT/gopath"
 mkdir "$GOPATH"
 unzip -qq -d "$GOPATH" "$GQL_ZIP"


### PR DESCRIPTION
Previously when trying to run a full build on the project, the example
project was failing on the gql target with the following error:

> bazel-out/darwin-opt-exec-2B5CBBC6/bin/gqlgen/generate:
> line 6: realpath: command not found

`realpath` is not available on a Mac prior to Ventura. We can work
around using it to avoid the user having to install extras into their
environment.

This patch replaces the use of `realpath` with the standard `pwd -P`
command that is available across both Linux and MacOS. This
implementation does not support the last segment of the path being a
symlink, but our use case doesn't require that at this time.